### PR TITLE
optimize ft_array_push functions

### DIFF
--- a/srcs/ft_arr_/ft_array_push_back.c
+++ b/srcs/ft_arr_/ft_array_push_back.c
@@ -9,20 +9,8 @@
 ** On success, the function returns the new size of the array.
 */
 
-static int	s_return_and_free(char **new_array, size_t total)
-{
-	while (total > 0)
-	{
-		total--;
-		ft_memdel((void **)&new_array[total]);
-	}
-	free(new_array);
-	return (-1);
-}
-
 int			ft_array_push_back(char ***array, char const *value)
 {
-	char	**new_array;
 	size_t	total;
 
 	if (!value || !array)
@@ -31,20 +19,5 @@ int			ft_array_push_back(char ***array, char const *value)
 	if (*array)
 		while ((*array)[total])
 			total++;
-	if ((new_array = (char **)malloc(sizeof(char *) * (total + 2))) == NULL)
-		return (s_return_and_free(new_array, 0));
-	total = 0;
-	if (*array)
-		while ((*array)[total])
-		{
-			if ((new_array[total] = ft_strdup((*array)[total])) == NULL)
-				return (s_return_and_free(new_array, total));
-			total++;
-		}
-	if ((new_array[total] = ft_strdup(value)) == NULL)
-		return (s_return_and_free(new_array, total));
-	new_array[++total] = NULL;
-	ft_memdel_tab((void ***)&(*array));
-	*array = new_array;
-	return (total);
+	return (ft_array_push_index(array, value, total));
 }

--- a/srcs/ft_arr_/ft_array_push_front.c
+++ b/srcs/ft_arr_/ft_array_push_front.c
@@ -9,42 +9,7 @@
 ** On success, the function returns the new size of the array.
 */
 
-static int	s_return_and_free(char **new_array, size_t total)
-{
-	while (total > 0)
-	{
-		total--;
-		ft_memdel((void **)&new_array[total]);
-	}
-	free(new_array);
-	return (-1);
-}
-
 int			ft_array_push_front(char ***array, char const *value)
 {
-	char	**new_array;
-	size_t	total;
-
-	if (!value || !array)
-		return (-1);
-	total = 0;
-	if (*array)
-		while ((*array)[total])
-			total++;
-	if ((new_array = (char **)malloc(sizeof(char *) * (total + 2))) == NULL)
-		return (s_return_and_free(new_array, 0));
-	if ((new_array[0] = ft_strdup(value)) == NULL)
-		return (s_return_and_free(new_array, 0));
-	total = 0;
-	if (*array)
-		while ((*array)[total])
-		{
-			if ((new_array[total + 1] = ft_strdup((*array)[total])) == NULL)
-				return (s_return_and_free(new_array, total));
-			total++;
-		}
-	new_array[++total] = NULL;
-	ft_memdel_tab((void ***)&(*array));
-	*array = new_array;
-	return (total);
+	return (ft_array_push_index(array, value, 0));
 }

--- a/srcs/ft_arr_/ft_array_push_index.c
+++ b/srcs/ft_arr_/ft_array_push_index.c
@@ -9,18 +9,7 @@
 ** On success, the function returns the new size of the array.
 */
 
-static int	s_return_and_free(char **new_array, size_t total)
-{
-	while (total > 0)
-	{
-		total--;
-		ft_memdel((void **)&new_array[total]);
-	}
-	free(new_array);
-	return (-1);
-}
-
-static int	s_iterate_on_array(char **array, char ***new_array,
+static void	s_iterate_on_array(char **array, char ***new_array,
 						size_t index, size_t *total)
 {
 	size_t	i;
@@ -33,12 +22,10 @@ static int	s_iterate_on_array(char **array, char ***new_array,
 			(*new_array)[*total] = NULL;
 			(*total)++;
 		}
-		if (((*new_array)[*total] = ft_strdup(array[i])) == NULL)
-			return (-1);
+		(*new_array)[*total] = array[i];
 		(*total)++;
 		i++;
 	}
-	return (0);
 }
 
 int			ft_array_push_index(char ***array, char const *value,
@@ -55,18 +42,17 @@ int			ft_array_push_index(char ***array, char const *value,
 	if (index > total)
 		index = total;
 	if ((new_array = (char **)malloc(sizeof(char *) * (total + 2))) == NULL)
-		return (s_return_and_free(new_array, 0));
+		return (-1);
 	if (*array && total > 0)
 	{
 		total = 0;
-		if (s_iterate_on_array(*array, &new_array, index, &total) == -1)
-			return (s_return_and_free(new_array, total));
+		s_iterate_on_array(*array, &new_array, index, &total);
 	}
 	total = total == 0 ? 1 : total;
 	if ((new_array[index] = ft_strdup(value)) == NULL)
-		return (s_return_and_free(new_array, total));
+		return (-1);
 	new_array[total] = NULL;
-	ft_memdel_tab((void ***)&(*array));
+	free(*array);
 	*array = new_array;
 	return (total);
 }


### PR DESCRIPTION
`ft_array_push_front` now returns `ft_array_push_index` with index 0
`ft_array_push_back` now returns `ft_array_push_index` with last index

`ft_array_push_index` does not duplicate and then free each value of the old array (as unnecessary)
